### PR TITLE
Remove static twitter:title metadata

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,7 +77,6 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
       hideableSidebar: true,
       metadatas: [
         {name: 'twitter:description', content: "A collection of articles and papers from Flashbots."},
-        {name: 'twitter:title', content: "Flashbots Writings"},
       ],
       image: 'img/tw-card.jpg',
       navbar: {


### PR DESCRIPTION
The static `twitter:title` metadata is overriding the desired dynamic title - `"Blog Post Title | Flashbots Writings"` for direct links to posts in Discord.

You can check the cards in OpenGraph.xyz: https://www.opengraph.xyz/url/https%3A%2F%2Fflashbots-writings-website-git-gkoscky-discord-title-flashbots.vercel.app%2Fpreparing-for-dencun

But that's not a complete test, as the Discord rendering there isn't the same as the latest Discord version. So here's a screenshot:
![image](https://github.com/flashbots/flashbots-writings-website/assets/68292774/10a0ce6e-7896-4d61-b51c-19c29120f737)
