### PR TITLE
Remove static title metadata

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,9 +75,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       hideableSidebar: true,
-      metadatas: [
-        {name: 'twitter:description', content: "A collection of articles and papers from Flashbots."},
-      ],
+      metadatas: [],
       image: 'img/tw-card.jpg',
       navbar: {
         title: "Flashbots",


### PR DESCRIPTION
The static header was overriding the blog post's blurb in links.

[OpenGraph Main Page](https://www.opengraph.xyz/url/https%3A%2F%2Fflashbots-writings-website-git-gkoscky-fix-title-flashbots.vercel.app)
[OpenGraph Blog Post](https://www.opengraph.xyz/url/https%3A%2F%2Fflashbots-writings-website-git-gkoscky-fix-title-flashbots.vercel.app%2Fpreparing-for-dencun)

